### PR TITLE
Fix: Print debug messages only in debug mode

### DIFF
--- a/decoder.cpp
+++ b/decoder.cpp
@@ -53,7 +53,7 @@ void decoder::execute_handler(sensordata_t &d)
 			 d.sequence, d.alarm, d.rssi,
 			 d.flags,
 			 d.ts);
-		if (dbg==1)
+		if (dbg>=1)
 			printf("EXEC %s\n",cmd);
 		(void)system(cmd);
 	}

--- a/fm_demod.cpp
+++ b/fm_demod.cpp
@@ -51,11 +51,11 @@ void fsk_demod::process(int16_t *data_iq, int len)
 		last_q=data_iq[i+1];
 	}
 	
-	if (dbg==2)
+	if (dbg>=2)
 		printf("Trigger ratio %i/%i \n",triggered,len/2);
 	if (triggered >= len/8) {
 		thresh+=5;
-		if (dbg==2)
+		if (dbg>=2)
 			printf("Adjust trigger level to %i\n",thresh);
 	}
 		

--- a/fm_demod.cpp
+++ b/fm_demod.cpp
@@ -53,11 +53,15 @@ void fsk_demod::process(int16_t *data_iq, int len)
 	
 	if (dbg>=2)
 		printf("Trigger ratio %i/%i \n",triggered,len/2);
+
+// disable faulty trigger level detection; see https://www.mikrocontroller.net/topic/417740#5044129
+/*
 	if (triggered >= len/8) {
 		thresh+=5;
 		if (dbg>=2)
 			printf("Adjust trigger level to %i\n",thresh);
 	}
+*/
 		
 }
 //-------------------------------------------------------------------------

--- a/sdr.cpp
+++ b/sdr.cpp
@@ -145,7 +145,7 @@ int sdr::set_frequency(uint32_t f)
 	int r;
 	r=rtlsdr_set_center_freq(dev, f);
 	cur_frequ=f;
-	if (dbg==1)
+	if (dbg>=1)
 		printf("Frequency %.4lfMHz\n",(float)(f/1e6));
 	return r;
 }

--- a/sdr.cpp
+++ b/sdr.cpp
@@ -184,14 +184,14 @@ int sdr::set_gain(int mode,float g)
 		return -1;
 	int r;
 	if (mode==0) {
-		if (dbg)
+		if (dbg>0)
 			printf("AUTO GAIN\n");
 
 		r=rtlsdr_set_tuner_gain_mode(dev,0);
 		cur_gain=0;
 	} else {
 		cur_gain=nearest_gain(g*10);
-		if (dbg)
+		if (dbg>0)
 			printf("GAIN %.1f\n",cur_gain/10.0);
 		r=rtlsdr_set_tuner_gain_mode(dev, 1);
 		r=rtlsdr_set_tuner_gain(dev, cur_gain);
@@ -215,7 +215,7 @@ int sdr::set_samplerate(int s)
 		return -1;
 	int r;
         r=rtlsdr_set_sample_rate(dev, s);
-	if (dbg)
+	if (dbg>0)
 		printf("Samplerate %i\n",s);
 	cur_sr=s;
 	return r;
@@ -250,7 +250,7 @@ static void sdr_read_callback(unsigned char *buf, uint32_t len, void *ctx)
 //-------------------------------------------------------------------------
 void sdr::read_thread(void)
 {
-	if (dbg)
+	if (dbg>0)
 		printf("START READ THREAD\n");
 	rtlsdr_read_async(dev, sdr_read_callback, this, 0, buffer_len/8);
 }

--- a/sdr.cpp
+++ b/sdr.cpp
@@ -5,7 +5,7 @@
         #include <GPL-v2>
 
   sdr.cpp -- wrapper around librtlsdr
- 
+
   Parts taken from librtlsdr (rtl_fm.c)
   rtl-sdr, turns your Realtek RTL2832 based DVB dongle into a SDR receiver
   Copyright (C) 2012 by Steve Markgraf <steve@steve-m.de>
@@ -32,7 +32,7 @@ sdr::sdr(int dev_index, int _dbg, int dumpmode, char *dumpfile)
 	running=0;
 	dev=NULL;
 	dump_fd=NULL;
-	
+
 	if (dumpmode>0 && dumpfile) {
 		dump_fd=fopen(dumpfile,"wb");
 		if (!dump_fd) {
@@ -55,13 +55,13 @@ sdr::sdr(int dev_index, int _dbg, int dumpmode, char *dumpfile)
 	int r;
 	while(1) {
 		r=rtlsdr_open(&dev, dev_index);
-		if (!r) 
+		if (!r)
 			break;
 		fprintf(stderr, "RET OPEN %i, retry\n",r);
 		sleep(1);
 	}
 	set_ppm(0);
-//	set_gain(0,0);	
+//	set_gain(0,0);
 	pthread_cond_init(&ready, NULL);
 	pthread_mutex_init(&ready_m, NULL);
 }
@@ -98,7 +98,7 @@ int sdr::search_device(char *substr)
 	return -1;
 }
 //-------------------------------------------------------------------------
-int sdr::start(void) 
+int sdr::start(void)
 {
 	if (!dev)
 		return -1;

--- a/tfa1.cpp
+++ b/tfa1.cpp
@@ -35,7 +35,7 @@
 
 //-------------------------------------------------------------------------
 tfa1_decoder::tfa1_decoder(void)
-{	
+{
 	sr=0;
 	sr_cnt=-1;
 	byte_cnt=0;
@@ -54,14 +54,14 @@ void tfa1_decoder::flush(int rssi, int offset)
 			printf("          ");
 		}
 		int id=((rdata[2]<<8)|rdata[3])&0x7fff;
-		int batfail=(rdata[7]&0x80)>>7; 
+		int batfail=(rdata[7]&0x80)>>7;
 		double temp=((rdata[4]&0xf)*100)+((rdata[5]>>4)*10)+(rdata[5]&0xf);
 		temp=(temp/10)-40;
 		int hum=rdata[6];
 		int seq=rdata[8]>>4;
 		uint8_t crc_val=rdata[10];
 		uint8_t crc_calc=crc->calc(&rdata[2],8);
-	       
+
 		// CRC and sanity checks
 		if ( crc_val==crc_calc
 		     && ((rdata[4]&0xf0)==0x80 // ignore all learning messages except sensor fails
@@ -75,17 +75,17 @@ void tfa1_decoder::flush(int rssi, int offset)
 			// .3181 has only temperature, humidity is 0x6a
 			if ( hum==0x6a)
 				hum=0;
-			
+
 			// Sensor values may fail at 0xaaa/0xfff or 0x7f due to low battery
 			// even without lowbat bit
-			// Set it to 2 -> sensor data not valid			
+			// Set it to 2 -> sensor data not valid
 			if (rdata[5]==0xff || rdata[5]==0xaa || hum==0x7f) {
 				batfail=2;
 				hum=0;
 				temp=0;
-			}			
-			
-			if (dbg>=0){
+			}
+
+			if (dbg>=0) {
 				printf("ID %04x %+.1f %i%%  seq %x lowbat %i RSSI %i\n",id,temp,hum,seq, batfail, rssi);
 				fflush(stdout);
 			}
@@ -136,14 +136,14 @@ tfa1_demod::tfa1_demod(decoder *_dec) : demodulator(_dec)
 {
 	mark_lvl=0;
 	rssi=0;
-	timeout_cnt=0;	
+	timeout_cnt=0;
 }
 //-------------------------------------------------------------------------
 int tfa1_demod::demod(int thresh, int pwr, int index, int16_t *iq)
 {
 	int triggered=0;
 	static int ld=0;
-	
+
 	if (pwr>thresh)
 		timeout_cnt=40*BITPERIOD;
 
@@ -156,7 +156,7 @@ int tfa1_demod::demod(int thresh, int pwr, int index, int16_t *iq)
 			mark_lvl=dev;
 		else
 			mark_lvl=mark_lvl*0.95 ;
-		
+
 		// remember peak for RSSI look-alike
 		if (mark_lvl>rssi)
 			rssi=mark_lvl;
@@ -185,7 +185,7 @@ int tfa1_demod::demod(int thresh, int pwr, int index, int16_t *iq)
 	}
 	last_i=iq[0];
 	last_q=iq[1];
-		
+
 	return triggered;
 }
 //-------------------------------------------------------------------------

--- a/tfa1.cpp
+++ b/tfa1.cpp
@@ -47,7 +47,7 @@ tfa1_decoder::tfa1_decoder(void)
 void tfa1_decoder::flush(int rssi, int offset)
 {
 	if (byte_cnt>=10) {
-		if (dbg) {
+		if (dbg>0) {
 			printf("#%03i %u  ",snum++,(uint32_t)time(0));
 			for(int n=0;n<11;n++)
 				printf("%02x ",rdata[n]);
@@ -103,7 +103,7 @@ void tfa1_decoder::flush(int rssi, int offset)
 		}
 		else {
 			bad++;
-			if (dbg) {
+			if (dbg>0) {
 				if (crc_val!=crc_calc)
 					printf("BAD %i RSSI %i (CRC %02x %02x)\n",bad,rssi,crc_val,crc_calc);
 				else

--- a/tfa2.cpp
+++ b/tfa2.cpp
@@ -6,7 +6,7 @@
 // Protocol for IT+ Sensors 30.3143/30.3144 and 30.3155
 //
 // FSK - modulation
-// NRZ 
+// NRZ
 // 30.3143,30.3144 (=TFA_2)
 //    Bitrate ~17240 bit/s -> @ 1.535MHz & 4x decimation -> 22.2 samples/bit
 //    Training sequence: 4* 1-0 toggles (8 bit)
@@ -19,7 +19,7 @@
 // 7 bytes total (inkl. sync, excl. training)
 //
 // Telegram format
-// 0x2d 0xd4 II IT TT HH CC 
+// 0x2d 0xd4 II IT TT HH CC
 // 2d d4: Sync bytes
 // III(11:8)=0x9 (at least for 3143/44/55)
 // III(7:2)= ID(7:2) (displayed at startup, last 2 bits of ID always 0)
@@ -65,16 +65,16 @@ void tfa2_decoder::flush(int rssi, int offset)
 		if (hum==0x7d)
 			sub_id=1;
 		id|=sub_id;
-		
+
 		if (crc_val==crc_calc
 		    ) {
 			if (hum>100)
 				hum=0;
-			
+
 			printf("ID %06x %+.1lf %i %02x %02x RSSI %i Offset %.0lfkHz\n",
 			       id,temp,hum,crc_val,crc_calc,rssi,
 			       -1536.0*offset/131072);
-			
+
 			sensordata_t sd;
 			sd.type=type;
 			sd.id=id;
@@ -115,7 +115,7 @@ void tfa2_decoder::store_bit(int bit)
 		byte_cnt=1;
 		invert=0;
 	}
-	
+
 	// Tolerate inverted sync (maybe useful later...)
 	if (((~sr)&0xffff)==0x2dd4) {
 		printf("Inverted SYNC\n");
@@ -124,7 +124,7 @@ void tfa2_decoder::store_bit(int bit)
 		byte_cnt=1;
 		invert=1;
 	}
-	
+
 	if (sr_cnt==0) {
 		if (byte_cnt<(int)sizeof(rdata)) {
 			if (invert)
@@ -141,7 +141,7 @@ void tfa2_decoder::store_bit(int bit)
 //-------------------------------------------------------------------------
 tfa2_demod::tfa2_demod(decoder *_dec, int _spb) : demodulator( _dec)
 {
-	spb=_spb;	
+	spb=_spb;
 	timeout_cnt=0;
 	reset();
 	iir=new iir2(0.5/spb); // Lowpass at bit frequency (01-pattern)
@@ -155,7 +155,7 @@ void tfa2_demod::reset(void)
 	dmin=32767;
 	dmax=-32767;
 	last_bit=0;
-	rssi=0;	
+	rssi=0;
 }
 //-------------------------------------------------------------------------
 // More debugging
@@ -169,12 +169,12 @@ int tfa2_demod::demod(int thresh, int pwr, int index, int16_t *iq)
 {
 	int triggered=0;
 	int ld=0;
-	
+
 	if (pwr>thresh) {
 		if (!timeout_cnt)
 			reset();
-		
-		timeout_cnt=16*spb;		
+
+		timeout_cnt=16*spb;
 	}
 
 	if (timeout_cnt) {
@@ -195,12 +195,12 @@ int tfa2_demod::demod(int thresh, int pwr, int index, int16_t *iq)
 				rssi+=(rssi+iq[0]*iq[0]+iq[1]*iq[1])/100;
 		}
 		timeout_cnt--;
-		
+
 		dev=ld;
 
 		// cheap compensation of 0/1 asymmetry if deviation limited in preceeding filter
-		int noffset=offset*0.75; 
-		
+		int noffset=offset*0.75;
+
 		int bit=0;
 		int margin=32;
 
@@ -222,9 +222,9 @@ int tfa2_demod::demod(int thresh, int pwr, int index, int16_t *iq)
 		if ((dev>noffset+dmax/margin || dev< noffset+dmin/margin) && bit!=last_bit) {
 			if (index>(last_bit_idx+8)) { // Ignore glitches
 				bitcnt++;
-				
+
 				// Determine number of bits depending on time between edges
-				if (index-last_bit_idx>spb/4) {				
+				if (index-last_bit_idx>spb/4) {
 
 					//printf("%i %i %i \n",bit,last_bit,(index-last_bit_idx)/2);
 					int numbits=(index-last_bit_idx)/2;
@@ -256,7 +256,7 @@ int tfa2_demod::demod(int thresh, int pwr, int index, int16_t *iq)
 	}
 	last_i=iq[0];
 	last_q=iq[1];
-		
+
 	return triggered;
 }
 //-------------------------------------------------------------------------

--- a/tfa2.cpp
+++ b/tfa2.cpp
@@ -47,7 +47,7 @@ void tfa2_decoder::flush(int rssi, int offset)
 {
 	//printf(" CNT %i\n",byte_cnt);
 	if (byte_cnt>=7) {
-		if (dbg) {
+		if (dbg>0) {
 			printf("#%03i %u  ",snum++,(uint32_t)time(0));
 			for(int n=0;n<7;n++)
 				printf("%02x ",rdata[n]);
@@ -89,7 +89,7 @@ void tfa2_decoder::flush(int rssi, int offset)
 		}
 		else {
 			bad++;
-			if (dbg) {
+			if (dbg>0) {
 				if (crc_val!=crc_calc)
 					printf("BAD %i RSSI %i  Offset %.0lfkHz (CRC %02x %02x)\n",bad,rssi,
 					       -1536.0*offset/131072,


### PR DESCRIPTION
I noticed that debug messages are printed even with "-q" set. I think I found and fixed the problem; the debug value for quiet ('-1') evaluates to true, so comparisons have to consider that.