### PR TITLE
Add support for 64-Bit ARM platform

### DIFF
--- a/Makefile.arm
+++ b/Makefile.arm
@@ -2,7 +2,7 @@ PACKAGES= librtlsdr
 
 CXX=g++
 
-PROFILING=
+PROFILING= #-g
 DEFINES=
 PKG_INCLUDES= $(shell pkg-config --cflags $(PACKAGES))
 PKG_LIBS= $(shell pkg-config --libs $(PACKAGES))
@@ -18,7 +18,7 @@ LIBS=-lm $(PKG_LIBS) -lpthread
 LDFLAGS=$(PROFILING) -rdynamic
 
 CFILES=main.cpp engine.cpp  dsp_stuff.cpp fm_demod.cpp decoder.cpp crc8.cpp \
-	tfa1.cpp tfa2.cpp utils.cpp sdr.cpp whb.cpp crc32.cpp
+	tfa1.cpp tfa2.cpp whb.cpp utils.cpp sdr.cpp crc32.cpp
 
 OBJS = $(CFILES:.cpp=.o)
 

--- a/Makefile.arm64
+++ b/Makefile.arm64
@@ -1,0 +1,45 @@
+# Makefile for ARM 64-bit
+PACKAGES= librtlsdr
+
+CXX=g++
+
+PROFILING= #-g
+DEFINES=
+PKG_INCLUDES= $(shell pkg-config --cflags $(PACKAGES))
+PKG_LIBS= $(shell pkg-config --libs $(PACKAGES))
+
+CXXFLAGS=-O3 $(PROFILING) -ftree-vectorize -ffast-math \
+	      -std=c++0x -Wall \
+	      -Wno-unused-function  -Wno-unused-variable -Wno-unused-but-set-variable \
+	      -Wno-write-strings
+
+INCLUDES= $(PKG_INCLUDES) 
+
+LIBS=-lm $(PKG_LIBS) -lpthread
+LDFLAGS=$(PROFILING) -rdynamic
+
+CFILES=main.cpp engine.cpp  dsp_stuff.cpp fm_demod.cpp decoder.cpp crc8.cpp \
+	tfa1.cpp tfa2.cpp whb.cpp utils.cpp sdr.cpp crc32.cpp
+
+OBJS = $(CFILES:.cpp=.o)
+
+all: tfrec
+
+tfrec: $(OBJS)
+	 $(CXX) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)
+
+.cpp.o:
+	$(CXX) $(CXXFLAGS) $(DEFINES) $(INCLUDES) -c $<
+
+ifneq ($(MAKECMDGOALS),clean)
+include .depend
+endif
+
+.depend: Makefile
+	touch .depend
+	makedepend $(DEF) $(INCL)  $(CFLAGS) $(CFILES) -f .depend >/dev/null 2>&1 || /bin/true
+
+clean :
+	$(RM) $(OBJS) *~
+	$(RM) tfrec
+	$(RM) .depend

--- a/Makefile.raspi2
+++ b/Makefile.raspi2
@@ -3,7 +3,7 @@ PACKAGES= librtlsdr
 
 CXX=g++
 
-PROFILING=
+PROFILING= #-g
 DEFINES=
 PKG_INCLUDES= $(shell pkg-config --cflags $(PACKAGES))
 PKG_LIBS= $(shell pkg-config --libs $(PACKAGES))
@@ -19,7 +19,7 @@ LIBS=-lm $(PKG_LIBS) -lpthread
 LDFLAGS=$(PROFILING) -rdynamic
 
 CFILES=main.cpp engine.cpp  dsp_stuff.cpp fm_demod.cpp decoder.cpp crc8.cpp \
-	tfa1.cpp tfa2.cpp utils.cpp sdr.cpp  whb.cpp crc32.cpp
+	tfa1.cpp tfa2.cpp whb.cpp utils.cpp sdr.cpp crc32.cpp
 
 OBJS = $(CFILES:.cpp=.o)
 


### PR DESCRIPTION
This request contains a Makefile to compile tfrec for the 64-Bit ARM platform (`aarch64` / `arm64`). It's just a copy of the `Makefile.arm` without unsupported compiler options.

In addition, minor differences between Makefiles have been removed.