### PR TITLE
main.cpp: fix device detection

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -112,7 +112,8 @@ int main(int argc, char **argv)
 		switch (c) {
 		case 'd':
 			deviceindex=strtol(optarg,NULL,10);
-			if (errno==EINVAL || errno==ERANGE) {
+			if (errno==EINVAL || errno==ERANGE ||
+			   strlen(optarg) > 4 || !strcmp(optarg,"?")) {  // Serialnumber
 				deviceindex=sdr::search_device(optarg);
 			}
 			break;


### PR DESCRIPTION
Device detection did not work on my Linux system. The variable errno was never set to EINVAL or ERANGE.